### PR TITLE
Update honggfuzz to the newest version (1ec27b2e3652e6c0c94c28f547226…

### DIFF
--- a/fuzzers/honggfuzz/builder.Dockerfile
+++ b/fuzzers/honggfuzz/builder.Dockerfile
@@ -23,14 +23,14 @@ RUN apt-get update -y && \
     libblocksruntime-dev \
     liblzma-dev
 
-# Download honggfuz version 2.1 + d0fbcb0373c32436b8fb922e6937da93b17291f5
+# Download honggfuz version 2.1 + 1ec27b2e3652e6c0c94c28f547226a2dc6009f04
 # Set CFLAGS use honggfuzz's defaults except for -mnative which can build CPU
 # dependent code that may not work on the machines we actually fuzz on.
 # Create an empty object file which will become the FUZZER_LIB lib (since
 # honggfuzz doesn't need this when hfuzz-clang(++) is used).
 RUN git clone https://github.com/google/honggfuzz.git /honggfuzz && \
     cd /honggfuzz && \
-    git checkout d0fbcb0373c32436b8fb922e6937da93b17291f5 && \
+    git checkout 1ec27b2e3652e6c0c94c28f547226a2dc6009f04 && \
     CFLAGS="-O3 -funroll-loops" make && \
     touch empty_lib.c && \
     cc -c -o empty_lib.o empty_lib.c


### PR DESCRIPTION
…a2dc6009f04) (#1045)

* Revert partially 2c4fba17e400c9c670fa0d06ef61aff004b5d76b so the older version of honggfuzz is used.

    This older version of honggfuzz displayed much better results than the
    newer ones, probably because 2751713e03e9733e01d84c4d31004e79c66e8ca9
    implemented a big change, which probably yields worse performance
    results.

    Compare e.g. this (older version):
    https://www.fuzzbench.com/reports/2020-08-03/index.html with e.g. this
    https://www.fuzzbench.com/reports/2020-09-18/index.html (newer version).

    I'll try to figure out what was the problem, but for now I propose
    treating d0fbcb0373c32436b8fb922e6937da93b17291f5 as golden standard for
    honggfuzz, and I'll use experiments to figure out the regression.

* Update honggfuzz to the newest version: 1ec27b2e3652e6c0c94c28f547226a2dc6009f04